### PR TITLE
Fix for error with empty composer.lock

### DIFF
--- a/optimize.sh
+++ b/optimize.sh
@@ -136,8 +136,7 @@ cat > composer.json <<EOF
 }
 EOF
 
-cat > composer.lock <<EOF
-EOF
+rm composer.lock
 
 curl -sS https://getcomposer.org/installer | php
 


### PR DESCRIPTION
If `composer.lock` is present but empty an error happens:

```
  [Seld\JsonLint\ParsingException]                                        
  "./composer.lock" does not contain valid JSON                           
  Parse error on line 1:                                                  
  ^                                                                       
  Expected one of: 'STRING', 'NUMBER', 'NULL', 'TRUE', 'FALSE', '{', '['  
```
